### PR TITLE
Use `test` as alias for `lint` for consistency

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "start": "next dev",
     "build": "next build && next export",
     "lint": "next lint",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "test": "npm run lint"
   },
   "author": "@double-great",
   "license": "MIT",


### PR DESCRIPTION
Running the dependency updater from #159 showed me that I missed that the testing step is `npm run lint`:
https://github.com/double-great/playground/actions/runs/4316525843/jobs/7532409962#step:6:7

This PR creates a `test` script that runs `npm run lint` so that the dependency update action can use the same YAML across all uses.